### PR TITLE
Set serverInfo.id if --test-server is specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ cmake_build/
 .idea/
 cmake-build-debug/
 cmake-build-linux/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/

--- a/main.cpp
+++ b/main.cpp
@@ -71,11 +71,12 @@ int main(const int argc, const char **argv) {
         std::cout << "PROVIDER=" << info.isp << std::endl;
     }
 
+    auto serverList = sp.serverList();
 
     if (programOptions.selected_server.empty()){
         if (programOptions.output_type == OutputType::verbose)
             std::cout << "Finding fastest server... " << std::flush;
-        auto serverList = sp.serverList();
+        
         if (serverList.empty()){
             std::cerr << "Unable to download server list. Try again later" << std::endl;
             return EXIT_FAILURE;
@@ -107,6 +108,11 @@ int main(const int argc, const char **argv) {
 
         serverInfo.host.append(programOptions.selected_server);
         sp.setServer(serverInfo);
+
+        for (auto &s : serverList) {
+            if (s.host == serverInfo.host)
+                serverInfo.id = s.id;
+        }
 
         if (programOptions.output_type == OutputType::verbose)
             std::cout << "Selected server: " << serverInfo.host << std::endl;


### PR DESCRIPTION
So that --share actually returns the correct url. Added Viusal Studio ignore to .gitignore.