### PR TITLE
Add undocumented options to the docs

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -20,10 +20,12 @@ void usage(const char* name){
     std::cerr << "optional arguments:" << std::endl;
     std::cerr << "  --help                      Show this message and exit\n";
     std::cerr << "  --latency                   Perform latency test only\n";
+    std::cerr << "  --quality                   Perform quality test only. It includes latency test\n";
     std::cerr << "  --download                  Perform download test only. It includes latency test\n";
     std::cerr << "  --upload                    Perform upload test only. It includes latency test\n";
     std::cerr << "  --share                     Generate and provide a URL to the speedtest.net share results image\n";
     std::cerr << "  --test-server host:port     Run speed test against a specific server\n";
+    std::cerr << "  --quality-server host:port  Run line quality test against a specific server\n";
     std::cerr << "  --output verbose|text|json  Set output type. Default: verbose\n";
 }
 


### PR DESCRIPTION
The documentation was present in README but not in `--help` of the app itself.

The undocumented options were:

--quality
--quality-server