### PR TITLE
Add option to skip ssl certificate verification for embedded devices.

### DIFF
--- a/CmdOptions.h
+++ b/CmdOptions.h
@@ -15,6 +15,7 @@ typedef struct program_options_t {
     bool download = false;
     bool upload   = false;
     bool share    = false;
+    bool insecure = false;
     std::string selected_server = "";
     OutputType output_type = OutputType::verbose;
 } ProgramOptions;
@@ -25,12 +26,13 @@ static struct option CmdLongOptions[] = {
         {"download",    no_argument,       0, 'd' },
         {"upload",      no_argument,       0, 'u' },
         {"share",       no_argument,       0, 's' },
+        {"insecure",    no_argument,       0, 'i' },
         {"test-server", required_argument, 0, 't' },
         {"output",      required_argument, 0, 'o' },
         {0,             0,                 0,  0  }
 };
 
-const char *optStr = "hldusqt:o:";
+const char *optStr = "hldusiqt:o:";
 
 bool ParseOptions(const int argc, const char **argv, ProgramOptions& options){
     int long_index =0;
@@ -51,6 +53,9 @@ bool ParseOptions(const int argc, const char **argv, ProgramOptions& options){
                 break;
             case 's':
                 options.share    = true;
+                break;
+            case 'i':
+                options.insecure = true;
                 break;
             case 't':
                 options.selected_server.append(optarg);

--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -264,7 +264,7 @@ CURLcode SpeedTest::httpGet(const std::string &url, std::stringstream &ss, CURL 
     if (curl){
         if (CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_FILE, &ss))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout))
-            && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, this->insecure))
+            && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, this->strict_ssl_verify))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_URL, url.c_str()))) {
             code = curl_easy_perform(curl);
         }
@@ -283,7 +283,7 @@ CURLcode SpeedTest::httpPost(const std::string &url, const std::string &postdata
         if (CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_FILE, &os))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_URL, url.c_str()))
-            && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, this->insecure))
+            && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, this->strict_ssl_verify))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postdata.c_str()))) {
             code = curl_easy_perform(curl);
         }
@@ -553,5 +553,7 @@ bool SpeedTest::testLatency(SpeedTestClient &client, const int sample_size, long
 }
 
 void SpeedTest::setInsecure(bool insecure) {
-    this->insecure = insecure;
+    // when insecure is on, we dont want ssl cert to be verified.
+    // when insecure is off, we want ssl cert to be verified.
+    this->strict_ssl_verify = !insecure;
 }

--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -264,6 +264,7 @@ CURLcode SpeedTest::httpGet(const std::string &url, std::stringstream &ss, CURL 
     if (curl){
         if (CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_FILE, &ss))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout))
+            && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, this->insecure))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_URL, url.c_str()))) {
             code = curl_easy_perform(curl);
         }
@@ -282,6 +283,7 @@ CURLcode SpeedTest::httpPost(const std::string &url, const std::string &postdata
         if (CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_FILE, &os))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_URL, url.c_str()))
+            && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, this->insecure))
             && CURLE_OK == (code = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postdata.c_str()))) {
             code = curl_easy_perform(curl);
         }
@@ -550,3 +552,6 @@ bool SpeedTest::testLatency(SpeedTestClient &client, const int sample_size, long
     return true;
 }
 
+void SpeedTest::setInsecure(bool insecure) {
+    this->insecure = insecure;
+}

--- a/SpeedTest.h
+++ b/SpeedTest.h
@@ -63,7 +63,7 @@ private:
     double mUploadSpeed;
     double mDownloadSpeed;
     float mMinSupportedServer;
-    bool insecure;
+    bool strict_ssl_verify;
 };
 
 

--- a/SpeedTest.h
+++ b/SpeedTest.h
@@ -38,6 +38,7 @@ public:
     const std::vector<ServerInfo>& serverList();
     const ServerInfo bestServer(int sample_size = 5, std::function<void(bool)> cb = nullptr);
     bool setServer(ServerInfo& server);
+    void setInsecure(bool insecure = false);
     const long &latency();
     bool downloadSpeed(const ServerInfo& server, const TestConfig& config, double& result, std::function<void(bool)> cb = nullptr);
     bool uploadSpeed(const ServerInfo& server, const TestConfig& config, double& result, std::function<void(bool)> cb = nullptr);
@@ -62,7 +63,7 @@ private:
     double mUploadSpeed;
     double mDownloadSpeed;
     float mMinSupportedServer;
-
+    bool insecure;
 };
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,7 @@ void usage(const char* name){
     std::cerr << "  --download                  Perform download test only. It includes latency test\n";
     std::cerr << "  --upload                    Perform upload test only. It includes latency test\n";
     std::cerr << "  --share                     Generate and provide a URL to the speedtest.net share results image\n";
+    std::cerr << "  --insecure                  Skip SSL certificate verify (Useful for Embedded devices)\n";
     std::cerr << "  --test-server host:port     Run speed test against a specific server\n";
     std::cerr << "  --quality-server host:port  Run line quality test against a specific server\n";
     std::cerr << "  --output verbose|text|json  Set output type. Default: verbose\n";
@@ -56,6 +57,10 @@ int main(const int argc, const char **argv) {
     IPInfo info;
     ServerInfo serverInfo;
     ServerInfo serverQualityInfo;
+    
+    if (programOptions.insecure) {
+        sp.setInsecure(programOptions.insecure);
+    }
 
     if (programOptions.output_type == OutputType::json)
         std::cout << "{";


### PR DESCRIPTION
Added insecure mode for embedded devices where there is no ca-certificates bundle

Signed-off-by: Harshal <harshalgohel@gmail.com>