### PR TITLE
update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM ubuntu:latest
+FROM ubuntu:latest as builder
 
 RUN mkdir -p /tmp/build /tmp/src
 COPY *.h *.cpp *.h.in CMakeLists.txt /tmp/src/
 
 
 RUN apt-get update && apt-get install -y g++ cmake make libcurl4-openssl-dev libxml2-dev libssl-dev && \
-    cd /tmp/build && cmake -DCMAKE_BUILD_TYPE=Release ../src && make install && \
-    apt-get remove --purge -y gcc make cmake libcurl4-openssl-dev libxml2-dev libssl-dev && \
-    apt-get remove --purge -y `apt-mark showauto` && \
-    apt-get install -y libxml2 libcurl3 && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/build /tmp/src
+    cd /tmp/build && cmake -DCMAKE_BUILD_TYPE=Release ../src && make install
+
+FROM ubuntu:latest
+RUN apt-get update && apt-get install -y libxml2 libcurl4
+COPY --from=builder /tmp/build/SpeedTest /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/SpeedTest"]


### PR DESCRIPTION
Fixes #27 by updating libcurl3 to libcurl4.  Also changed the build process to use a multistage build rather than the steps to remove the additional packages only required for build.