### PR TITLE
Remove dependency on libxml2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ add_executable(SpeedTest ${SOURCE_FILES})
 
 INCLUDE (CheckIncludeFiles)
 find_package(CURL REQUIRED)
-find_package(LibXml2 REQUIRED)
 
 if (NOT (APPLE))
     find_package(OpenSSL REQUIRED)
@@ -52,7 +51,7 @@ else()
     CHECK_INCLUDE_FILES("CommonCrypto/CommonDigest.h" HAVE_COMMON_DIGEST_H)
 endif()
 
-include_directories(${CURL_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR})
-target_link_libraries(SpeedTest ${CURL_LIBRARIES} ${LIBXML2_LIBRARIES} -lpthread ${OPENSSL_LIBRARIES})
+include_directories(${CURL_INCLUDE_DIRS})
+target_link_libraries(SpeedTest ${CURL_LIBRARIES} -lpthread ${OPENSSL_LIBRARIES})
 
 install(TARGETS SpeedTest RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ It supports the new (undocumented) raw TCP protocol for better accuracy.
 2. cmake
 3. libcurl
 4. libssl
-5. libxml2
 
 ### On Mac OS X
 
@@ -40,7 +39,7 @@ $ make install
 ### On Ubuntu/Debian
 
 ```
-$ sudo apt-get install build-essential libcurl4-openssl-dev libxml2-dev libssl-dev cmake
+$ sudo apt-get install build-essential libcurl4-openssl-dev libssl-dev cmake
 $ git clone https://github.com/taganaka/SpeedTest
 $ cd SpeedTest
 $ cmake -DCMAKE_BUILD_TYPE=Release .
@@ -50,7 +49,7 @@ $ sudo make install
 ### On OpenSuse
 
 ```
-$ sudo zypper install cmake gcc-c++ libcurl-devel libxml2-devel libopenssl-devel git
+$ sudo zypper install cmake gcc-c++ libcurl-devel libopenssl-devel git
 $ git clone https://github.com/taganaka/SpeedTest
 $ cd SpeedTest
 $ cmake -DCMAKE_BUILD_TYPE=Release .

--- a/SpeedTest.h
+++ b/SpeedTest.h
@@ -7,7 +7,6 @@
 
 #include "SpeedTestConfig.h"
 #include "SpeedTestClient.h"
-#include <libxml/xmlreader.h>
 #include <functional>
 #include <cmath>
 #include <curl/curl.h>
@@ -50,7 +49,6 @@ private:
     const ServerInfo findBestServerWithin(const std::vector<ServerInfo>& serverList, long& latency, int sample_size = 5, std::function<void(bool)> cb = nullptr);
     static CURL* curl_setup(CURL* curl = nullptr);
     static size_t writeFunc(void* buf, size_t size, size_t nmemb, void* userp);
-    static ServerInfo processServerXMLNode(xmlTextReaderPtr reader);
     double execute(const ServerInfo &server, const TestConfig &config, const opFn &fnc, std::function<void(bool)> cb = nullptr);
     template <typename T>
         static T deg2rad(T n);


### PR DESCRIPTION
Having libxml2 for parsing one simple xml file looks like overkill for me.

This PR removes the dependency on libxml2. In my particular case, it allowed me to build the binary and put it into an embedded device.