### PR TITLE
Enhance: Provide list of available speed test servers #63

### DIFF
--- a/CmdOptions.h
+++ b/CmdOptions.h
@@ -16,6 +16,7 @@ typedef struct program_options_t {
     bool upload   = false;
     bool share    = false;
     bool insecure = false;
+    bool list_servers  = false;
     std::string selected_server = "";
     OutputType output_type = OutputType::verbose;
 } ProgramOptions;
@@ -27,12 +28,13 @@ static struct option CmdLongOptions[] = {
         {"upload",      no_argument,       0, 'u' },
         {"share",       no_argument,       0, 's' },
         {"insecure",    no_argument,       0, 'i' },
+        {"list-servers",no_argument,       0, 'L' },
         {"test-server", required_argument, 0, 't' },
         {"output",      required_argument, 0, 'o' },
         {0,             0,                 0,  0  }
 };
 
-const char *optStr = "hldusiqt:o:";
+const char *optStr = "hldusiqLt:o:";
 
 bool ParseOptions(const int argc, const char **argv, ProgramOptions& options){
     int long_index =0;
@@ -56,6 +58,9 @@ bool ParseOptions(const int argc, const char **argv, ProgramOptions& options){
                 break;
             case 'i':
                 options.insecure = true;
+                break;
+            case 'L':
+                options.list_servers = true;
                 break;
             case 't':
                 options.selected_server.append(optarg);

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@ void usage(const char* name){
     std::cerr << "  --upload                    Perform upload test only. It includes latency test\n";
     std::cerr << "  --share                     Generate and provide a URL to the speedtest.net share results image\n";
     std::cerr << "  --insecure                  Skip SSL certificate verify (Useful for Embedded devices)\n";
+    std::cerr << "  --list-servers              List available speed test servers\n";
     std::cerr << "  --test-server host:port     Run speed test against a specific server\n";
     std::cerr << "  --quality-server host:port  Run line quality test against a specific server\n";
     std::cerr << "  --output verbose|text|json  Set output type. Default: verbose\n";
@@ -55,6 +56,32 @@ int main(const int argc, const char **argv) {
 
 
     auto sp = SpeedTest(SPEED_TEST_MIN_SERVER_VERSION);
+
+    if (programOptions.list_servers) {
+        if (programOptions.output_type == OutputType::json) {
+            std::cout << "[";
+            const auto &servers = sp.serverList();
+            bool first = true;
+            for (const auto &server : servers) {
+                if (!first) {
+                    std::cout << ",";
+                }
+                std::cout << "{\"id\":\"" << server.id << "\",\"host\":\"" << server.host
+                          << "\",\"country\":\"" << server.country << "\",\"sponsor\":\"" << server.sponsor << "\"}";
+                first = false;
+            }
+            std::cout << "]" << std::endl;
+        } else {
+            const auto &servers = sp.serverList();
+            for (const auto &server : servers) {
+                std::cout << "ID: " << server.id << ", Host: " << server.host
+                          << ", Country: " << server.country << ", Sponsor: " << server.sponsor << std::endl;
+            }
+        }
+
+        return EXIT_SUCCESS;
+    }
+
     IPInfo info;
     ServerInfo serverInfo;
     ServerInfo serverQualityInfo;


### PR DESCRIPTION
**@ubuntu:~/Desktop/SpeedTest/build$** `./SpeedTest -L --output json`
[{"id":"36268","host":"speed1.boominfotech.net:8080","country":"Pakistan","sponsor":"Boom Info Tech (Smc-Pvt) Ltd"},{"id":"52792","host":"speedtest.babunetworks.com:8080","country":"Pakistan","sponsor":"Babu Networks"},{"id":"21678","host":"speedtest.visiontelecom.com.pk:8080","country":"Pakistan","sponsor":"VISION TELECOM (Pvt) LTD"},{"id":"30431","host":"speedtest.optix.pk:8080","country":"Pakistan","sponsor":"Optix Pakistan (Pvt) Ltd"},{"id":"4512","host":"speedtest1.nexlinx.net.pk:8080","country":"Pakistan","sponsor":"Nexlinx Networks (Pvt) Ltd"},{"id":"31079","host":"speed.cactuspk.com:8080","country":"Pakistan","sponsor":"Cactus Network Solutions (CNS) Pvt Ltd"},{"id":"48801","host":"speedtest2.rds.net.pk:8080","country":"Pakistan","sponsor":"Redtone Digital Services"},{"id":"29890","host":"speedtest.connectel.com.pk:8080","country":"Pakistan","sponsor":"ConnecTEL"},{"id":"59713","host":"speedtest.smartpk.net:8080","country":"Pakistan","sponsor":"SMART MULTIMEDIA"},{"id":"60566","host":"ookla.elb.com.pk:8080","country":"Pakistan","sponsor":"EarthLink Broadband"}]


**@ubuntu:~/Desktop/SpeedTest/build$** `./SpeedTest -L`
SpeedTest++ version 1.15
Speedtest.net command line interface
Info: https://github.com/taganaka/SpeedTest
Fixed: https://github.com/gglluukk/SpeedTest
Author: Francesco Laurita <francesco.laurita@gmail.com>

ID: 36268, Host: speed1.boominfotech.net:8080, Country: Pakistan, Sponsor: Boom Info Tech (Smc-Pvt) Ltd
ID: 52792, Host: speedtest.babunetworks.com:8080, Country: Pakistan, Sponsor: Babu Networks
ID: 21678, Host: speedtest.visiontelecom.com.pk:8080, Country: Pakistan, Sponsor: VISION TELECOM (Pvt) LTD
ID: 30431, Host: speedtest.optix.pk:8080, Country: Pakistan, Sponsor: Optix Pakistan (Pvt) Ltd
ID: 4512, Host: speedtest1.nexlinx.net.pk:8080, Country: Pakistan, Sponsor: Nexlinx Networks (Pvt) Ltd
ID: 31079, Host: speed.cactuspk.com:8080, Country: Pakistan, Sponsor: Cactus Network Solutions (CNS) Pvt Ltd
ID: 48801, Host: speedtest2.rds.net.pk:8080, Country: Pakistan, Sponsor: Redtone Digital Services
ID: 29890, Host: speedtest.connectel.com.pk:8080, Country: Pakistan, Sponsor: ConnecTEL
ID: 59713, Host: speedtest.smartpk.net:8080, Country: Pakistan, Sponsor: SMART MULTIMEDIA
ID: 60566, Host: ookla.elb.com.pk:8080, Country: Pakistan, Sponsor: EarthLink Broadband


**@ubuntu:~/Desktop/SpeedTest/build$** `./SpeedTest --list-servers`
SpeedTest++ version 1.15
Speedtest.net command line interface
Info: https://github.com/taganaka/SpeedTest
Fixed: https://github.com/gglluukk/SpeedTest
Author: Francesco Laurita <francesco.laurita@gmail.com>

ID: 36268, Host: speed1.boominfotech.net:8080, Country: Pakistan, Sponsor: Boom Info Tech (Smc-Pvt) Ltd
ID: 52792, Host: speedtest.babunetworks.com:8080, Country: Pakistan, Sponsor: Babu Networks
ID: 21678, Host: speedtest.visiontelecom.com.pk:8080, Country: Pakistan, Sponsor: VISION TELECOM (Pvt) LTD
ID: 30431, Host: speedtest.optix.pk:8080, Country: Pakistan, Sponsor: Optix Pakistan (Pvt) Ltd
ID: 4512, Host: speedtest1.nexlinx.net.pk:8080, Country: Pakistan, Sponsor: Nexlinx Networks (Pvt) Ltd
ID: 31079, Host: speed.cactuspk.com:8080, Country: Pakistan, Sponsor: Cactus Network Solutions (CNS) Pvt Ltd
ID: 48801, Host: speedtest2.rds.net.pk:8080, Country: Pakistan, Sponsor: Redtone Digital Services
ID: 29890, Host: speedtest.connectel.com.pk:8080, Country: Pakistan, Sponsor: ConnecTEL
ID: 59713, Host: speedtest.smartpk.net:8080, Country: Pakistan, Sponsor: SMART MULTIMEDIA
ID: 60566, Host: ookla.elb.com.pk:8080, Country: Pakistan, Sponsor: EarthLink Broadband
